### PR TITLE
ci: add manual Release E2E workflow + MCP Registry publish/verify

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,105 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semantic version (e.g., 0.3.0)"
+        required: true
+        type: string
+
+env:
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  bump_and_tag:
+    name: Bump version, commit via GitHub App, and tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv (standard)
+        if: env.ACT != 'true'
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: latest
+
+      - name: Install uv (act fallback)
+        if: env.ACT == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install uv
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Bump version in files
+        id: bump
+        run: |
+          uv run python scripts/bump_version.py --version "${{ inputs.version }}" | tee bump.log
+          echo "summary=$(grep '^SUMMARY: ' bump.log | sed 's/^SUMMARY: //')" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub App token
+        if: env.ACT != 'true'
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Configure git user
+        run: |
+          git config user.name "mcp-release-bot"
+          git config user.email "mcp-release-bot@users.noreply.github.com"
+
+      - name: Commit changes (if any)
+        run: |
+          set -e
+          if git diff --quiet; then
+            echo "No working tree changes to commit."
+          else
+            git add -A
+            git commit -m "chore(release): bump version to ${{ inputs.version }}"
+          fi
+
+      - name: Push commit (skip under act)
+        if: env.ACT != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -e
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          git push origin "HEAD:${CURRENT_BRANCH}"
+
+      - name: Create tag
+        run: |
+          set -e
+          TAG="v${{ inputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally; skipping tag creation."
+          else
+            git tag "$TAG"
+          fi
+
+      - name: Push tag (skip under act)
+        if: env.ACT != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -e
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Summary
+        run: echo "Prepared release v${{ inputs.version }}."

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -1,0 +1,97 @@
+name: Release E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semantic version (e.g., 0.3.0)"
+        required: true
+        type: string
+
+env:
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  prepare_and_push:
+    name: Bump, commit, tag, and push (main)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: latest
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Validate input version and tag uniqueness
+        id: validate
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid version format: $VERSION (expected MAJOR.MINOR.PATCH)" >&2
+            exit 1
+          fi
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists locally" >&2
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Bump version in files
+        run: |
+          uv run python scripts/bump_version.py --version "${{ steps.validate.outputs.VERSION }}" | tee bump.log
+
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Configure git user
+        run: |
+          git config user.name "mcp-release-bot"
+          git config user.email "mcp-release-bot@users.noreply.github.com"
+
+      - name: Ensure on main branch
+        run: |
+          git fetch origin main --tags
+          git checkout main
+
+      - name: Commit changes (if any)
+        run: |
+          set -e
+          if git diff --quiet; then
+            echo "No working tree changes to commit."
+          else
+            git add -A
+            git commit -m "chore(release): bump version to ${{ steps.validate.outputs.VERSION }}"
+          fi
+
+      - name: Create tag
+        run: |
+          git tag "v${{ steps.validate.outputs.VERSION }}"
+
+      - name: Push commit and tag to origin/main
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -e
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin HEAD:main
+          git push origin "v${{ steps.validate.outputs.VERSION }}"
+
+      - name: Summary
+        run: echo "Pushed commit and tag v${{ steps.validate.outputs.VERSION }}. The Release workflow will run automatically."
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,114 +11,145 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  release:
-    name: Create Release
+  build_dist:
+    name: Build sdist/wheel and verify version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: latest
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+      - name: Extract version from tag
+        id: ver
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Verify version matches pyproject.toml
+        run: |
+          PROJECT_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          test "$PROJECT_VERSION" = "${{ steps.ver.outputs.VERSION }}"
+      - name: Clean dist directory
+        run: rm -rf dist/
+      - name: Build package
+        run: uv build --no-sources
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish_pypi:
+    name: Publish to PyPI
+    needs: build_dist
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  docker_build_push:
+    name: Build & push multi-arch image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Extract version from tag
+        id: ver
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.ver.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  create_release:
+    name: Create GitHub Release with artifacts
+    needs: build_dist
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
-      id-token: write
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Generate changelog
+        id: changelog
+        run: |
+          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          echo "## Changes in ${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 HEAD^)..HEAD >> $GITHUB_OUTPUT || echo "- Initial release" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${GITHUB_REF#refs/tags/}
+          name: Release ${GITHUB_REF#refs/tags/}
+          body: ${{ steps.changelog.outputs.CHANGELOG }}
+          draft: false
+          prerelease: false
+          files: |
+            dist/*
+          generate_release_notes: true
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        version: "latest"
-
-    - name: Set up Python
-      run: uv python install ${{ env.PYTHON_VERSION }}
-
-    - name: Install dependencies
-      run: uv sync --all-extras --dev
-
-    - name: Extract version from tag
-      id: version
-      run: |
-        VERSION=${GITHUB_REF#refs/tags/v}
-        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-        echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
-    - name: Verify version matches pyproject.toml
-      run: |
-        PROJECT_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-        if [ "$PROJECT_VERSION" != "${{ steps.version.outputs.VERSION }}" ]; then
-          echo "Version mismatch: tag=${{ steps.version.outputs.VERSION }}, pyproject.toml=$PROJECT_VERSION"
-          exit 1
-        fi
-
-    - name: Generate changelog
-      id: changelog
-      run: |
-        # Simple changelog generation - you can enhance this
-        echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-        echo "## Changes in ${{ steps.version.outputs.TAG }}" >> $GITHUB_OUTPUT
-        git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 HEAD^)..HEAD >> $GITHUB_OUTPUT || echo "- Initial release" >> $GITHUB_OUTPUT
-        echo "" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
-
-    - name: Clean dist directory
-      run: |
-        rm -rf dist/
-
-    - name: Build package
-      run: |
-        uv build --no-sources
-
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-
-    - name: Log in to Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract metadata for Docker
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-          type=ref,event=tag
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
-          type=raw,value=latest,enable={{is_default_branch}}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          VERSION=${{ steps.version.outputs.VERSION }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ steps.version.outputs.TAG }}
-        name: Release ${{ steps.version.outputs.TAG }}
-        body: ${{ steps.changelog.outputs.CHANGELOG }}
-        draft: false
-        prerelease: false
-        files: |
-          dist/*
-        generate_release_notes: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish_mcp_registry:
+    name: Publish to MCP Registry (preview)
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install MCP Publisher CLI
+        run: brew install mcp-publisher
+      - name: Initialize server metadata (idempotent)
+        run: mcp-publisher init || true
+      - name: Publish to MCP Registry
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,17 +139,69 @@ jobs:
 
   publish_mcp_registry:
     name: Publish to MCP Registry (preview)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     continue-on-error: true
     steps:
       - uses: actions/checkout@v5
       - name: Install MCP Publisher CLI
-        run: brew install mcp-publisher
-      - name: Initialize server metadata (idempotent)
-        run: mcp-publisher init || true
-      - name: Publish to MCP Registry
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Extract version from tag
+        id: ver
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - name: Generate server.json
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mcp-publisher publish
+          VERSION: ${{ steps.ver.outputs.VERSION }}
+        run: |
+          python - <<'PY'
+          import json, tomllib, os
+          VERSION = os.environ['VERSION']
+          with open('pyproject.toml','rb') as f:
+              proj = tomllib.load(f)['project']
+          desc = proj.get('description','')
+          data = {
+            "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+            "name": "io.github.othervibes/mcp-as-a-judge",
+            "description": desc,
+            "version": VERSION,
+            "packages": [
+              {"registry_type": "pypi", "identifier": "mcp-as-a-judge", "version": VERSION},
+              {"registry_type": "oci", "registry_base_url": "https://ghcr.io", "identifier": "othervibes/mcp-as-a-judge", "version": VERSION}
+            ]
+          }
+          with open('server.json','w') as f: json.dump(data,f,indent=2)
+          PY
+      - name: Login to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+      - name: Verify publication
+        env:
+          NAME: io.github.othervibes/mcp-as-a-judge
+        run: |
+          for i in {1..10}; do
+            sleep 3
+            curl -sf "https://registry.modelcontextprotocol.io/v0/servers?search=$NAME" -o out.json || true
+            python - <<'PY'
+          import json, sys, os
+          name = os.environ['NAME']
+          try:
+              data=json.load(open('out.json'))
+          except Exception:
+              sys.exit(1)
+          items = []
+          if isinstance(data, dict):
+              items = data.get('results') or data.get('servers') or data.get('data') or []
+          elif isinstance(data, list):
+              items = data
+          ok = any(isinstance(s, dict) and s.get('name') == name for s in items)
+          sys.exit(0 if ok else 1)
+          PY
+            if [ $? -eq 0 ]; then echo "Verified $NAME in registry"; exit 0; fi
+          done
+          echo "Server not visible in registry yet"
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 CMD ["mcp-as-a-judge"]
 
 # Labels for metadata
-LABEL org.opencontainers.image.title="MCP as a Judge" \
+LABEL io.modelcontextprotocol.server.name="io.github.othervibes/mcp-as-a-judge" \
+      org.opencontainers.image.title="MCP as a Judge" \
       org.opencontainers.image.description="AI-powered code evaluation and software engineering best practices enforcement" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.authors="Zvi Fried" \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP as a Judge ⚖️
 
+<!-- mcp-name: io.github.othervibes/mcp-as-a-judge -->
+
 <div align="left">
   <img src="assets/mcp-as-a-judge.png" alt="MCP as a Judge Logo" width="200">
 </div>
@@ -102,6 +104,16 @@ For troubleshooting, visit the [FAQs section](#faq).
 Configure **MCP as a Judge** in your MCP-enabled client:
 
 ### **Method 1: Using Docker (Recommended)**
+
+#### One‑click install for VS Code (MCP)
+
+Add this server to VS Code (GitHub Copilot) using Docker with automatic image pull:
+
+- Install link: https://insiders.vscode.dev/redirect/mcp/install?name=mcp-as-a-judge&inputs=%5B%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22--pull%3Dalways%22%2C%22ghcr.io%2Fothervibes%2Fmcp-as-a-judge%3Alatest%22%5D%7D
+
+Notes:
+- VS Code controls the sampling model; select it via “MCP: List Servers → mcp-as-a-judge → Configure Model Access”.
+
 
 1. **Configure MCP Settings:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-as-a-judge"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP as a Judge: An AI-powered Model Context Protocol server that provides code review, validation, and quality assessment tools for development workflows"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -47,7 +47,7 @@ def _write_text(path: Path, content: str) -> None:
 def extract_current_version() -> str:
     text = _read_text(PYPROJECT_PATH)
     # naive toml line parse to avoid adding deps
-    m = re.search(r"^version\s*=\s*\"([^"]+)\"", text, re.MULTILINE)
+    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
     if not m:
         print("ERROR: Could not find [project].version in pyproject.toml", file=sys.stderr)
         sys.exit(2)
@@ -57,8 +57,8 @@ def extract_current_version() -> str:
 def bump_pyproject(version: str) -> bool:
     content = _read_text(PYPROJECT_PATH)
     new_content, n = re.subn(
-        r"^(version\s*=\s*)\"[^\"]+\"",
-        rf"\1\"{version}\"",
+        r'^(version\s*=\s*)"[^\"]+"',
+        rf'\1"{version}"',
         content,
         flags=re.MULTILINE,
     )
@@ -74,8 +74,8 @@ def bump_pyproject(version: str) -> bool:
 def bump_init(version: str) -> bool:
     content = _read_text(INIT_PATH)
     new_content, n = re.subn(
-        r"^__version__\s*=\s*\"[^\"]+\"",
-        rf"__version__ = \"{version}\"",
+        r'^__version__\s*=\s*"[^\"]+"',
+        rf'__version__ = "{version}"',
         content,
         flags=re.MULTILINE,
     )

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Version bump utility for mcp-as-a-judge.
+
+- Validates a semantic version (MAJOR.MINOR.PATCH)
+- Updates version in:
+  * pyproject.toml -> [project].version
+  * src/mcp_as_a_judge/__init__.py -> __version__
+- Scans the repo and reports other files containing the old version (without modifying them),
+  so we can review drift. Known safe patterns can be extended here in the future.
+
+Usage:
+  python scripts/bump_version.py --version 0.3.0
+
+Outputs:
+  - Prints a machine-readable list of modified files on stdout (one per line) preceded by 'UPDATED: '
+  - Prints a machine-readable list of other files containing the old version preceded by 'FOUND: '
+  - Exits non-zero on validation failure or if expected files are missing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+INIT_PATH = REPO_ROOT / "src" / "mcp_as_a_judge" / "__init__.py"
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"ERROR: File not found: {path}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def extract_current_version() -> str:
+    text = _read_text(PYPROJECT_PATH)
+    # naive toml line parse to avoid adding deps
+    m = re.search(r"^version\s*=\s*\"([^"]+)\"", text, re.MULTILINE)
+    if not m:
+        print("ERROR: Could not find [project].version in pyproject.toml", file=sys.stderr)
+        sys.exit(2)
+    return m.group(1)
+
+
+def bump_pyproject(version: str) -> bool:
+    content = _read_text(PYPROJECT_PATH)
+    new_content, n = re.subn(
+        r"^(version\s*=\s*)\"[^\"]+\"",
+        rf"\1\"{version}\"",
+        content,
+        flags=re.MULTILINE,
+    )
+    if n:
+        _write_text(PYPROJECT_PATH, new_content)
+        print(f"UPDATED: {PYPROJECT_PATH.relative_to(REPO_ROOT)}")
+        return True
+    else:
+        print("WARN: version field not updated in pyproject.toml", file=sys.stderr)
+        return False
+
+
+def bump_init(version: str) -> bool:
+    content = _read_text(INIT_PATH)
+    new_content, n = re.subn(
+        r"^__version__\s*=\s*\"[^\"]+\"",
+        rf"__version__ = \"{version}\"",
+        content,
+        flags=re.MULTILINE,
+    )
+    if n:
+        _write_text(INIT_PATH, new_content)
+        print(f"UPDATED: {INIT_PATH.relative_to(REPO_ROOT)}")
+        return True
+    else:
+        print("WARN: __version__ not found in __init__.py", file=sys.stderr)
+        return False
+
+
+def find_other_references(old_version: str) -> None:
+    # Report-only scan for the old version string across repo (excluding venvs, git, dist, etc.)
+    skip_dirs = {".git", ".venv", "dist", "build", "__pycache__", ".mypy_cache", ".ruff_cache"}
+    for path in REPO_ROOT.rglob("*"):
+        if path.is_dir():
+            if path.name in skip_dirs:
+                # prune by skipping children
+                for _ in []:
+                    pass
+            continue
+        if path.suffix in {".png", ".jpg", ".jpeg", ".gif", ".zip", ".whl", ".tar", ".gz"}:
+            continue
+        # Avoid scanning the lock file for noisy matches
+        if path.name == "uv.lock":
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        if old_version in text:
+            print(f"FOUND: {path.relative_to(REPO_ROOT)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bump project version across files")
+    parser.add_argument("--version", required=True, help="Semantic version, e.g., 0.3.0")
+    args = parser.parse_args()
+
+    new_version = args.version.strip()
+    if not SEMVER_RE.match(new_version):
+        print(f"ERROR: Invalid semantic version: {new_version}", file=sys.stderr)
+        sys.exit(2)
+
+    current = extract_current_version()
+    if current == new_version:
+        print(f"INFO: Version already {new_version}; no changes needed.")
+        sys.exit(0)
+
+    # Update files
+    ok1 = bump_pyproject(new_version)
+    ok2 = bump_init(new_version)
+    if not (ok1 or ok2):
+        print("ERROR: No files were updated; aborting.", file=sys.stderr)
+        sys.exit(2)
+
+    # Report other references to the OLD version (so humans can review)
+    find_other_references(current)
+
+    # Emit a small JSON summary for the workflow if needed
+    summary = {
+        "old_version": current,
+        "new_version": new_version,
+    }
+    print(f"SUMMARY: {json.dumps(summary)}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/mcp_as_a_judge/__init__.py
+++ b/src/mcp_as_a_judge/__init__.py
@@ -5,7 +5,7 @@ This package provides MCP tools for validating coding plans and code changes
 against software engineering best practices.
 """
 
-__version__ = "1.0.0"
+__version__ = "0.3.0"
 
 
 # Lazy imports to avoid dependency issues in Cloudflare Workers


### PR DESCRIPTION
This PR adds a manual end-to-end release workflow (workflow_dispatch) that:
- bumps version, commits to main via GitHub App, creates & pushes tag
- triggers existing Release workflow (PyPI, Docker multi-arch, GitHub Release, MCP Registry publish + verify)

Also includes:
- OCI label on Dockerfile for MCP Registry validation
- mcp-name marker in README
- Ubuntu/OIDC publisher in release.yml with verification step